### PR TITLE
handle when we have no config file per #49

### DIFF
--- a/identity/__init__.py
+++ b/identity/__init__.py
@@ -10,9 +10,12 @@ try:
     import identity.config as config
 except Exception as e:
     config_error = """
-        You need to create/install a <project-home>/identity/config.py file and populate it with some values.
-        Please see https://github.com/synshop/ShopIdentifyer/blob/master/README.md for more information."""
-    app.logger.info(e)
+Your "config.py" file is missing. You need to 
+create and populate it with some values. Please  
+see https://github.com/synshop/ShopIdentifyer/  
+for more information.
+"""
+    print(config_error)
     quit()
 
 from apscheduler.schedulers.background import BackgroundScheduler


### PR DESCRIPTION
Decided to KISS and just go for `print()` as the app looked pretty dependent on the config file to instantiate.

I also removed the indentation and added more line wraps as it was hard to read with them - see screenshot below.

Finally the URL was a 404, so I updated it to use the `prod` branch and no deep link to readme.

![image](https://user-images.githubusercontent.com/8253488/203669621-b7774afd-c982-45e7-8e56-7de9c1087cce.png)
