### PR TITLE
fix crypt command, add more error handling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Some of the features included are:
 
    For Ubuntu, this looks like:
    
-       $ apt-get install python3-dev python3.10-venv mysql-server build-essential \
+       apt-get install python3-dev python3.10-venv mysql-server build-essential \
               python3-pip libmysqlclient-dev git gh nginx libffi-dev
 
 2. Set up a [python virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/), clone or download the source for ShopIdentifyer and pip install the requirements.txt file included:
@@ -67,16 +67,11 @@ You can access the server at http://localhost:8000
 
 ### Encrypted values
 
-Please note that all of the properties starting with `ENCRYPTED_` are encrypted.  When the application starts up, it will prompt you for a single decryption password.  This is the same password that you will use to encrypt the properties using the cli tool `./identity/crypto/crypt.py`.  The instructions for use are pretty straightforward:
+Please note that all of the properties starting with `ENCRYPTED_` are encrypted.  When the application starts up, it will prompt you for a single decryption password.  This is the same password that you will use to encrypt the properties using the cli tool `./identity/crypto/encrypt` and `./identity/crypto/decrypt`.
 
-    $ python crypt.py
+In order for the decryption to work, you need to use the same password to encrypt all of the 6 values. Here's an example of encrypting the string `foo` with the password of also `foo`:
 
-    Usage: crypt.py encrypt
-           crypt.py decrypt
-
-In order for the decryption to work, you need to use the same password to encrypt all of the 6 values. Here's an example of encrypting the string "foo"
-
-    $ python identity/crypto/crypt.py encrypt
+    python3 identity/crypto/encrypt
     Please enter the encryption key:
     Please enter the plaintext you wish to encrypt:
     Encrypted Value: +uBiga/44gMDfr6UXFllIA==
@@ -84,6 +79,13 @@ In order for the decryption to work, you need to use the same password to encryp
 So, if you wanted `foo` to be the value for the `ENCRYPTED_DATABASE_PASSWORD` you would define it like this in `config.py`:
 
     ENCRYPTED_DATABASE_PASSWORD = '+uBiga/44gMDfr6UXFllIA=='
+
+If you need to decrypt, it's the same process, but in reverse:
+
+    python3 ./identity/crypto/decrypt
+    Please enter the decryption key: 
+    Please enter the ciphertext you wish to decrypt: 
+    Plaintext Value: foo
 
 Again, you need to use the same password for each of the 6 encrypted strings in your config file.
 

--- a/identity/crypto/crypt.py
+++ b/identity/crypto/crypt.py
@@ -5,30 +5,52 @@ import sys, getpass
 import CryptoUtil
 from CryptoUtil import KeyLengthError
 
-def usage():
-    exit()
 
 def main(args):
 
-    op = args[0]
+    op = args[1]
 
     if 'encrypt' in op:
         key = getpass.getpass('Please enter the encryption key: ')
         plaintext = getpass.getpass('Please enter the plaintext you wish to encrypt: ')
-        try:
-            encrypted_value = CryptoUtil.encrypt(plaintext, key)
-            print("Encrypted Value: " + encrypted_value)
-        except KeyLengthError as ex:
-            print (ex)
+        if len(key) > 0 or len(plaintext) > 0:
+            try:
+                encrypted_value = CryptoUtil.encrypt(plaintext, key)
+                print("Encrypted Value: " + encrypted_value)
+            except KeyLengthError as ex:
+                print('ERROR', 'Key Length Error')
+                print(ex)
+            except Exception as e:
+                print('ERROR', 'Error in encrypting. Please check in inputs and try again.')
+                print(e)
+        else:
+            print('Key and plaintext must be at least 1 character long')
+
+        quit()
 
     if 'decrypt' in op:
-        key = getpass.getpass('Please enter the encryption key: ')
-        encrypted_value = getpass.getpass('Please enter the encrypted string you wish to decrypt: ')
-        try:
-            decrypted_value = CryptoUtil.decrypt(encrypted_value, key)
-            print("Plaintext Value: " + decrypted_value)
-        except KeyLengthError as ex:
-            print(ex)
+        key = getpass.getpass('Please enter the decryption key: ')
+        ciphertext = getpass.getpass('Please enter the ciphertext you wish to decrypt: ')
+
+        if len(key) > 0 or len(ciphertext) > 0:
+            try:
+                decrypted_value = CryptoUtil.decrypt(ciphertext, key)
+                print("Plaintext Value: " + decrypted_value)
+            except KeyLengthError as ex:
+                print('ERROR', 'Key Length Error')
+                print(ex)
+            except Exception as e:
+                print('ERROR', 'Error in decrypting. Please check in inputs and try again.')
+                print(e)
+
+        else:
+            print('Key and ciphertext must be at least 1 character long')
+
+        quit()
+
+    else:
+        print('Valid arguments: "encrypt" or "decrypt". See https://github.com/synshop/ShopIdentifyer')
+
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/identity/crypto/crypt.py
+++ b/identity/crypto/crypt.py
@@ -8,7 +8,11 @@ from CryptoUtil import KeyLengthError
 
 def main(args):
 
-    op = args[1]
+    if len(args) > 1 or args[0] == './identity/crypto/crypt.py':
+        print('Do not call this directly, use symlinks. See https://github.com/synshop/ShopIdentifyer')
+        quit()
+
+    op = args[0]
 
     if 'encrypt' in op:
         key = getpass.getpass('Please enter the encryption key: ')


### PR DESCRIPTION
per #53

main issue was that [here](https://github.com/synshop/ShopIdentifyer/blob/prod/identity/crypto/crypt.py#L13), `args[0]` is equal to `identity/crypto/crypt.py` .  Fix was to make it  `args[1]` which is the second argument.

As well, I added error handling and removed 1 line `usage()` function to simplify.